### PR TITLE
linux duckdb snapshot fix

### DIFF
--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -1,21 +1,6 @@
 name: LinuxRelease
 on:
-  workflow_call:
-    inputs:
-      override_git_describe:
-        type: string
-      git_ref:
-        type: string
-      skip_tests:
-        type: string
   workflow_dispatch:
-    inputs:
-      override_git_describe:
-        type: string
-      git_ref:
-        type: string
-      skip_tests:
-        type: string
   repository_dispatch:
   push:
     branches:

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -184,3 +184,4 @@ jobs:
             libduckdb-linux-aarch64.zip
             duckdb_odbc-linux-aarch64.zip
             duckdb_cli-linux-aarch64.zip
+

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -184,4 +184,3 @@ jobs:
             libduckdb-linux-aarch64.zip
             duckdb_odbc-linux-aarch64.zip
             duckdb_cli-linux-aarch64.zip
-

--- a/.github/workflows/LinuxRelease.yml
+++ b/.github/workflows/LinuxRelease.yml
@@ -1,6 +1,21 @@
 name: LinuxRelease
 on:
+  workflow_call:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   workflow_dispatch:
+    inputs:
+      override_git_describe:
+        type: string
+      git_ref:
+        type: string
+      skip_tests:
+        type: string
   repository_dispatch:
   push:
     branches:

--- a/src/common/file_system.cpp
+++ b/src/common/file_system.cpp
@@ -415,7 +415,7 @@ void FileSystem::MoveFile(const string &source, const string &target, optional_p
 	throw NotImplementedException("%s: MoveFile is not implemented!", GetName());
 }
 
-void FileSystem::CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle, unique_ptr<FileHandle>& dst_handle) {
+void FileSystem::CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle) {
 	throw NotImplementedException("%s: CopyFile is not implemented!", GetName());
 }
   

--- a/src/common/virtual_file_system.cpp
+++ b/src/common/virtual_file_system.cpp
@@ -101,8 +101,8 @@ void VirtualFileSystem::MoveFile(const string &source, const string &target, opt
 	FindFileSystem(source).MoveFile(source, target, opener);
 }
 
-void VirtualFileSystem::CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle, unique_ptr<FileHandle>& dst_handle) {
-  FindFileSystem(source).CopyFile(source, target, src_handle, dst_handle);
+void VirtualFileSystem::CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle) {
+  FindFileSystem(source).CopyFile(source, target, src_handle);
 }
 
 bool VirtualFileSystem::FileExists(const string &filename, optional_ptr<FileOpener> opener) {

--- a/src/include/duckdb/common/file_system.hpp
+++ b/src/include/duckdb/common/file_system.hpp
@@ -151,7 +151,7 @@ public:
 	//! properties
 	DUCKDB_API virtual void MoveFile(const string &source, const string &target,
 	                                 optional_ptr<FileOpener> opener = nullptr);
-	DUCKDB_API virtual void CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle, unique_ptr<FileHandle>& dst_handle);
+	DUCKDB_API virtual void CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle);
 
         //! Check if a file exists
 	DUCKDB_API virtual bool FileExists(const string &filename, optional_ptr<FileOpener> opener = nullptr);

--- a/src/include/duckdb/common/local_file_system.hpp
+++ b/src/include/duckdb/common/local_file_system.hpp
@@ -56,7 +56,7 @@ public:
 	//! Move a file from source path to the target, StorageManager relies on this being an atomic action for ACID
 	//! properties
 	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener = nullptr) override;
-        void CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle, unique_ptr<FileHandle>& dst_handle) override;
+        void CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle) override;
 	//! Check if a file exists
 	bool FileExists(const string &filename, optional_ptr<FileOpener> opener = nullptr) override;
 

--- a/src/include/duckdb/common/opener_file_system.hpp
+++ b/src/include/duckdb/common/opener_file_system.hpp
@@ -89,8 +89,8 @@ public:
 		GetFileSystem().MoveFile(source, target, GetOpener());
 	}
 
-        void CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle, unique_ptr<FileHandle>& dst_handle) override {
-	  GetFileSystem().CopyFile(source, target, src_handle, dst_handle);
+        void CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle) override {
+	  GetFileSystem().CopyFile(source, target, src_handle);
 	}
 
 	string GetHomeDirectory() override {

--- a/src/include/duckdb/common/virtual_file_system.hpp
+++ b/src/include/duckdb/common/virtual_file_system.hpp
@@ -47,7 +47,7 @@ public:
 	               FileOpener *opener = nullptr) override;
 
 	void MoveFile(const string &source, const string &target, optional_ptr<FileOpener> opener) override;
-        void CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle, unique_ptr<FileHandle>& dst_handle) override;
+        void CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle) override;
 	bool FileExists(const string &filename, optional_ptr<FileOpener> opener) override;
 
 	bool IsPipe(const string &filename, optional_ptr<FileOpener> opener) override;

--- a/src/main/capi/stream-c.cpp
+++ b/src/main/capi/stream-c.cpp
@@ -15,28 +15,28 @@ duckdb_data_chunk duckdb_stream_fetch_chunk(duckdb_result result) {
 }
 
 duckdb_data_chunk duckdb_fetch_chunk(duckdb_result result) {
-  Printer::PrintF("duckdb_fetch_chunk1\n");
+  duckdb::Printer::PrintF("duckdb_fetch_chunk1\n");
 	if (!result.internal_data) {
 		return nullptr;
 	}
-          Printer::PrintF("duckdb_fetch_chunk2\n");
+          duckdb::Printer::PrintF("duckdb_fetch_chunk2\n");
 	auto &result_data = *((duckdb::DuckDBResultData *)result.internal_data);
-          Printer::PrintF("duckdb_fetch_chunk3\n");
+          duckdb::Printer::PrintF("duckdb_fetch_chunk3\n");
 	if (result_data.result_set_type == duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED) {
 		return nullptr;
 	}
-          Printer::PrintF("duckdb_fetch_chunk4\n");
+          duckdb::Printer::PrintF("duckdb_fetch_chunk4\n");
 	result_data.result_set_type = duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_STREAMING;
 	auto &result_instance = (duckdb::QueryResult &)*result_data.result;
-          Printer::PrintF("duckdb_fetch_chunk5\n");
+          duckdb::Printer::PrintF("duckdb_fetch_chunk5\n");
 	// FetchRaw ? Do we care about flattening them?
 	try {
-            Printer::PrintF("duckdb_fetch_chunk6\n");
+            duckdb::Printer::PrintF("duckdb_fetch_chunk6\n");
 		auto chunk = result_instance.Fetch();
-                  Printer::PrintF("duckdb_fetch_chunk7\n");
+                  duckdb::Printer::PrintF("duckdb_fetch_chunk7\n");
 		return reinterpret_cast<duckdb_data_chunk>(chunk.release());
 	} catch (std::exception &e) {
-            Printer::PrintF("duckdb_fetch_chunk8\n");
+            duckdb::Printer::PrintF("duckdb_fetch_chunk8\n");
 		return nullptr;
 	}
 }

--- a/src/main/capi/stream-c.cpp
+++ b/src/main/capi/stream-c.cpp
@@ -1,7 +1,7 @@
 #include "duckdb/main/capi/capi_internal.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/allocator.hpp"
-
+#include "duckdb/common/printer.hpp"
 duckdb_data_chunk duckdb_stream_fetch_chunk(duckdb_result result) {
 	if (!result.internal_data) {
 		return nullptr;
@@ -15,20 +15,28 @@ duckdb_data_chunk duckdb_stream_fetch_chunk(duckdb_result result) {
 }
 
 duckdb_data_chunk duckdb_fetch_chunk(duckdb_result result) {
+  Printer::PrintF("duckdb_fetch_chunk1\n");
 	if (!result.internal_data) {
 		return nullptr;
 	}
+          Printer::PrintF("duckdb_fetch_chunk2\n");
 	auto &result_data = *((duckdb::DuckDBResultData *)result.internal_data);
+          Printer::PrintF("duckdb_fetch_chunk3\n");
 	if (result_data.result_set_type == duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_DEPRECATED) {
 		return nullptr;
 	}
+          Printer::PrintF("duckdb_fetch_chunk4\n");
 	result_data.result_set_type = duckdb::CAPIResultSetType::CAPI_RESULT_TYPE_STREAMING;
 	auto &result_instance = (duckdb::QueryResult &)*result_data.result;
+          Printer::PrintF("duckdb_fetch_chunk5\n");
 	// FetchRaw ? Do we care about flattening them?
 	try {
+            Printer::PrintF("duckdb_fetch_chunk6\n");
 		auto chunk = result_instance.Fetch();
+                  Printer::PrintF("duckdb_fetch_chunk7\n");
 		return reinterpret_cast<duckdb_data_chunk>(chunk.release());
 	} catch (std::exception &e) {
+            Printer::PrintF("duckdb_fetch_chunk8\n");
 		return nullptr;
 	}
 }

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -360,12 +360,11 @@ uint64_t SingleFileStorageManager::GetSnapshotId() {
 string SingleFileStorageManager::Snapshot() {
   uint64_t sid = dynamic_cast<SingleFileBlockManager *>(block_manager.get())->GetSnapshotId();
   unique_ptr<FileHandle>& src_handle = dynamic_cast<SingleFileBlockManager *>(block_manager.get())->GetFileHandle();
-   unique_ptr<FileHandle> dst_handle = dynamic_cast<SingleFileBlockManager *>(block_manager.get())->CloneEmptyDatabase();
   string ret = path;
   ret += ".";
   ret += to_string(sid);
   auto &fs = FileSystem::Get(db);
-  fs.CopyFile(path, ret, src_handle, dst_handle);
+  fs.CopyFile(path, ret, src_handle);
   return ret;
 }
  


### PR DESCRIPTION
This fixes the duckdb snapshot issue on linux with the correct implementation of sendfile.