### PR TITLE
linux copy file fix

### DIFF
--- a/src/common/local_file_system.cpp
+++ b/src/common/local_file_system.cpp
@@ -1379,8 +1379,8 @@ void LocalFileSystem::CopyFile(const string &source, const string &target, uniqu
 }
 #elif __linux__
 void LocalFileSystem::CopyFile(const string &source, const string &target, unique_ptr<FileHandle>& src_handle) {
-	int dst_fd = open(target.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);;
-	int src_fd = src_handle->Cast<UnixFileHandle>().fd;
+	int dst_fd = open(target.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+	int src_fd = open(source.c_str(), O_RDONLY);
 	off_t len, ret;
 	struct stat stat;
 


### PR DESCRIPTION
The bug was only in the linux version of CopyFile() function which copies the duckdb database file into a snapshot file.Before the fix, we are using the source file descriptor already opened by duckdb block manager as an argument
to sendfile. But that file descriptor might be at any offset in the source file including at the end of the file in which
case we copy only zero bytes. The fix is to create a new file descriptor by opening the source file which is
guaranteed to be at the beginning offset of the source file.